### PR TITLE
do more frequent resetNode

### DIFF
--- a/vendor/github.com/hashicorp/memberlist/state.go
+++ b/vendor/github.com/hashicorp/memberlist/state.go
@@ -620,6 +620,8 @@ func (m *Memberlist) gossip() {
 // reasonably expensive as the entire state of this node is exchanged
 // with the other node.
 func (m *Memberlist) pushPull() {
+	// clean up dead nodes
+	m.resetNodes();
 	// Get a random live node
 	m.nodeLock.RLock()
 	nodes := kRandomNodes(1, m.nodes, func(n *nodeState) bool {


### PR DESCRIPTION
resetNodes() is called when in probe() when a full circle of probe() finishes. It removed dead nodes and is why the conflict-of-node-id error go away by itself. This PR do it in a pushPull() now (which is called every 30 seconds), which means we do the cleanup much more frequently.

